### PR TITLE
Enable building from a git submodule

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,16 +18,19 @@ WORKDIR /opt/nodemcu-firmware
 # - FLOAT_ONLY=1, if you want the floating point firmware
 #
 # What the commands do:
-# - store the Git branch in 'BRANCH'
+# - store the Git branch in 'BRANCH' if IMAGE_NAME not set
 # - unpack esp-open-sdk.tar.gz in a directory that is NOT the bound mount directory (i.e. inside the Docker image)
 # - remove all files in <firmware-dir>/bin
 # - make a float build if !only-integer
 # - copy and rename the mapfile to bin/
 # - make an integer build
 # - copy and rename the mapfile to bin/
-CMD BRANCH="$(git rev-parse --abbrev-ref HEAD)" && \
-    BUILD_DATE="$(date +%Y%m%d-%H%M)" && \
-    if [ -z "$IMAGE_NAME" ]; then IMAGE_NAME=${BRANCH}_${BUILD_DATE}; else true; fi && \
+CMD BUILD_DATE="$(date +%Y%m%d-%H%M)" && \
+    if [ -z "$IMAGE_NAME" ]; then \
+      BRANCH="$(git rev-parse --abbrev-ref HEAD)" && \
+      IMAGE_NAME=${BRANCH}_${BUILD_DATE}; \
+    else true; \
+    fi && \
     cp tools/esp-open-sdk.tar.gz ../ && \
     cd ..  && \
     tar -zxvf esp-open-sdk.tar.gz  && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,9 @@ WORKDIR /opt/nodemcu-firmware
 # - copy and rename the mapfile to bin/
 # - make an integer build
 # - copy and rename the mapfile to bin/
-CMD BUILD_DATE="$(date +%Y%m%d-%H%M)" && \
-    if [ -z "$IMAGE_NAME" ]; then \
+CMD if [ -z "$IMAGE_NAME" ]; then \
       BRANCH="$(git rev-parse --abbrev-ref HEAD)" && \
+      BUILD_DATE="$(date +%Y%m%d-%H%M)" && \
       IMAGE_NAME=${BRANCH}_${BUILD_DATE}; \
     else true; \
     fi && \


### PR DESCRIPTION
Reordered statements so that git is not required if 'IMAGE_NAME' option is set. This makes it possible to run the docker image on a git submodule.
